### PR TITLE
chore: fix 'make docker' warns

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   replay-api:
     container_name: "replay-api"


### PR DESCRIPTION
* remove deprecated `version` tag