### PR TITLE
feat(REPL-126): add avatar and user consent preferences from steam integration

### DIFF
--- a/cmd/rest-api/controllers/steam_controller.go
+++ b/cmd/rest-api/controllers/steam_controller.go
@@ -34,7 +34,7 @@ func (c *SteamController) OnboardSteamUser(apiContext context.Context) http.Hand
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
 		if r.Body == nil {
-			slog.ErrorContext(r.Context(), "no request body", "request", r)
+			slog.ErrorContext(r.Context(), "no request body", "request.Body", r.Body)
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
@@ -43,13 +43,15 @@ func (c *SteamController) OnboardSteamUser(apiContext context.Context) http.Hand
 		var steamUserParams steam_entity.SteamUser
 		err := decoder.Decode(&steamUserParams)
 
+		// slog.InfoContext(r.Context(), "SteamUser Received =>", "steam_entity.SteamUser", steamUserParams)
+
 		if err != nil {
-			slog.ErrorContext(r.Context(), "error decoding steam user from request", "err", err, "request", r)
+			slog.ErrorContext(r.Context(), "error decoding steam user from request", "err", err, "request.body", r.Body)
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
 
-		err = c.OnboardSteamUserCommand.Validate(r.Context(), steamUserParams.Steam.ID, steamUserParams.VHash)
+		err = c.OnboardSteamUserCommand.Validate(r.Context(), steamUserParams)
 
 		if err != nil {
 			slog.ErrorContext(r.Context(), "error validating steam user", "err", err, "steamUserParams", steamUserParams)
@@ -57,7 +59,7 @@ func (c *SteamController) OnboardSteamUser(apiContext context.Context) http.Hand
 			return
 		}
 
-		steamUser, err := c.OnboardSteamUserCommand.Exec(r.Context(), steamUserParams.Steam.ID, steamUserParams.VHash)
+		steamUser, err := c.OnboardSteamUserCommand.Exec(r.Context(), steamUserParams)
 
 		if err != nil {
 			slog.ErrorContext(r.Context(), "error onboarding steam user", "err", err, "steamUserParams.Steam.ID", steamUserParams.Steam.ID, "steamUserParams.VHash", steamUserParams.VHash)

--- a/pkg/domain/steam/ports/in/cmd.go
+++ b/pkg/domain/steam/ports/in/cmd.go
@@ -7,6 +7,6 @@ import (
 )
 
 type OnboardSteamUserCommand interface {
-	Exec(ctx context.Context, steamID string, vHash string) (*e.SteamUser, error)
-	Validate(ctx context.Context, steamID string, vHash string) error
+	Exec(ctx context.Context, steamUser e.SteamUser) (*e.SteamUser, error)
+	Validate(ctx context.Context, steamUser e.SteamUser) error
 }

--- a/pkg/infra/ioc/container_test.go
+++ b/pkg/infra/ioc/container_test.go
@@ -45,13 +45,17 @@ func TestResolveOnboardSteamUserCommand(t *testing.T) {
 	ctx = context.WithValue(ctx, common.ClientIDKey, common.TeamPROAppClientID)
 	ctx = context.WithValue(ctx, common.UserIDKey, uuid.New())
 
-	err = command.Validate(ctx, "1", "8d2f508f233cea95b70b14ac0b7b9ae58d01ec3029ab8a08dac96234bc5f5746")
+	steamUser := steam_entity.SteamUser{ID: uuid.New(),
+		Steam: steam_entity.Steam{
+			ID: "8d2f508f233cea95b70b14ac0b7b9ae58d01ec3029ab8a08dac96234bc5f5746",
+		}}
+	err = command.Validate(ctx, steamUser)
 
 	if err != nil {
 		t.Fatalf("failed to validate OnboardSteamUserCommand: %v", err)
 	}
 
-	_, err = command.Exec(ctx, "1", "8d2f508f233cea95b70b14ac0b7b9ae58d01ec3029ab8a08dac96234bc5f5746")
+	_, err = command.Exec(ctx, steamUser)
 
 	if err != nil {
 		t.Fatalf("failed to validate OnboardSteamUserCommand: %v", err)

--- a/test/cmd/rest-api-test/http_api_test.go
+++ b/test/cmd/rest-api-test/http_api_test.go
@@ -68,7 +68,7 @@ func expectStatus(t *testing.T, expected int, r *httptest.ResponseRecorder) {
 // 	expectStatus(t, http.StatusOK, response)
 // }
 
-func Test_Search_Player_Success(t *testing.T) {
+func Test_Search_Player_SuccessEmpty(t *testing.T) {
 	tester := NewTester()
 
 	req, _ := http.NewRequest("GET", strings.Replace(routing.Search, "{query:.*}", "players/123", 1), nil)
@@ -78,7 +78,7 @@ func Test_Search_Player_Success(t *testing.T) {
 
 	t.Logf("response: %v", res)
 
-	expectStatus(t, http.StatusOK, res)
+	expectStatus(t, http.StatusNoContent, res)
 }
 
 func Test_SteamOnboarding_BadRequest(t *testing.T) {
@@ -92,8 +92,7 @@ func Test_SteamOnboarding_BadRequest(t *testing.T) {
 
 	expectStatus(t, http.StatusBadRequest, response)
 }
-
-func Test_GameEventSearch_Success(t *testing.T) {
+func Test_GameEventSearch_SuccessEmpty(t *testing.T) {
 	tester := NewTester()
 
 	req, _ := http.NewRequest("GET", strings.Replace(routing.Search, "{query:.*}", "GameEvents", 1), nil)
@@ -102,7 +101,7 @@ func Test_GameEventSearch_Success(t *testing.T) {
 
 	t.Logf("response: %v", response)
 
-	expectStatus(t, http.StatusOK, response)
+	expectStatus(t, http.StatusNoContent, response)
 }
 
 func Test_SteamOnboarding_Success(t *testing.T) {
@@ -115,9 +114,11 @@ func Test_SteamOnboarding_Success(t *testing.T) {
 		t.Errorf("fail to resolve steam_out.VHashWriter %v", err)
 	}
 
-	vhash := vHashWriter.CreateVHash(context.Background(), "1")
+	mockSteamID := "12345"
 
-	steamUser := fmt.Sprintf(`{"steam": {"id": "1"}, "v_hash": "%s"}`, vhash)
+	vhash := vHashWriter.CreateVHash(context.Background(), mockSteamID)
+
+	steamUser := fmt.Sprintf(`{"steam": {"id": "%s"}, "v_hash": "%s"}`, mockSteamID, vhash)
 	reader := strings.NewReader(steamUser)
 
 	req, _ := http.NewRequest("POST", routing.OnboardSteam, reader)


### PR DESCRIPTION
* Enrich SteamUser integration + Consent data from Steam configuration

* Example:
![image](https://github.com/user-attachments/assets/f31603cb-ccbe-4eda-a32f-25244f084bba)
