### PR TITLE
REPL-117 google resource-ownership consent, token

### DIFF
--- a/.coverage/coverage.html
+++ b/.coverage/coverage.html
@@ -746,7 +746,7 @@ func (m *ResourceContextMiddleware) Handler(next http.Handler) http.Handler <spa
                 ctx = context.WithValue(ctx, common.GroupIDKey, uuid.New())
                 ctx = context.WithValue(ctx, common.UserIDKey, uuid.New())
 
-                rid := r.Header.Get("x-resource-owner-id")
+                rid := r.Header.Get("X-Resource-Owner-ID")
                 if rid == "" </span><span class="cov10" title="2">{
                         next.ServeHTTP(w, r.WithContext(ctx))
                         return
@@ -754,7 +754,7 @@ func (m *ResourceContextMiddleware) Handler(next http.Handler) http.Handler <spa
 
                 <span class="cov0" title="0">reso, err := m.VerifyRID.Exec(ctx, uuid.MustParse(rid))
                 if err != nil </span><span class="cov0" title="0">{
-                        slog.ErrorContext(ctx, "unable to verify rid", "x-resource-owner-id", rid)
+                        slog.ErrorContext(ctx, "unable to verify rid", "X-Resource-Owner-ID", rid)
                         http.Error(w, "unknown", http.StatusUnauthorized)
                 }</span>
 

--- a/cmd/rest-api/controllers/google_controller.go
+++ b/cmd/rest-api/controllers/google_controller.go
@@ -75,7 +75,7 @@ func (c *GoogleController) OnboardGoogleUser(apiContext context.Context) http.Ha
 
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("x-resource-owner-id", ridToken.GetID().String())
+		w.Header().Set("X-Resource-Owner-ID", ridToken.GetID().String())
 		json.NewEncoder(w).Encode(googleUser)
 	}
 }

--- a/cmd/rest-api/controllers/steam_controller.go
+++ b/cmd/rest-api/controllers/steam_controller.go
@@ -75,7 +75,7 @@ func (c *SteamController) OnboardSteamUser(apiContext context.Context) http.Hand
 
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("x-resource-owner-id", ridToken.GetID().String())
+		w.Header().Set("X-Resource-Owner-ID", ridToken.GetID().String())
 		json.NewEncoder(w).Encode(steamUser)
 	}
 }

--- a/cmd/rest-api/middlewares/resource_context_middleware.go
+++ b/cmd/rest-api/middlewares/resource_context_middleware.go
@@ -35,7 +35,7 @@ func (m *ResourceContextMiddleware) Handler(next http.Handler) http.Handler {
 		ctx = context.WithValue(ctx, common.GroupIDKey, uuid.New())
 		ctx = context.WithValue(ctx, common.UserIDKey, uuid.New())
 
-		rid := r.Header.Get("x-resource-owner-id")
+		rid := r.Header.Get("X-Resource-Owner-ID")
 		if rid == "" {
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
@@ -43,7 +43,7 @@ func (m *ResourceContextMiddleware) Handler(next http.Handler) http.Handler {
 
 		reso, err := m.VerifyRID.Exec(ctx, uuid.MustParse(rid))
 		if err != nil {
-			slog.ErrorContext(ctx, "unable to verify rid", "x-resource-owner-id", rid)
+			slog.ErrorContext(ctx, "unable to verify rid", "X-Resource-Owner-ID", rid)
 			http.Error(w, "unknown", http.StatusUnauthorized)
 		}
 

--- a/pkg/domain/context.go
+++ b/pkg/domain/context.go
@@ -15,5 +15,5 @@ const (
 
 	// Request (ie: msg header, meta)
 	RequestIDKey            ContextKey = "x-request-id"
-	ResourceOwnerIDParamKey ContextKey = "x-resource-owner-id"
+	ResourceOwnerIDParamKey ContextKey = "X-Resource-Owner-ID"
 )

--- a/test/cmd/rest-api-test/http_api_test.go
+++ b/test/cmd/rest-api-test/http_api_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -55,6 +56,19 @@ func expectStatus(t *testing.T, expected int, r *httptest.ResponseRecorder) {
 	if expected != r.Code {
 		t.Errorf("Expected response code %d. Got %d\n Body=%v", expected, r.Code, r.Body)
 	}
+}
+
+func expectUUIDHeader(t *testing.T, key string, r *httptest.ResponseRecorder) {
+	if len(r.Header().Get(key)) == 0 {
+		t.Errorf("Expected response header %s to be a valid UUID. Got %s", key, r.Header().Get(key))
+	}
+
+	uuidRegEx := `^[\w\d]{8}-[\w\d]{4}-[\w\d]{4}-[\w\d]{4}-[\w\d]{12}$`
+
+	if !regexp.MustCompile(uuidRegEx).MatchString(r.Header().Get(key)) {
+		t.Errorf("Expected response header %s to be a UUID. Got %s", key, r.Header().Get(key))
+	}
+
 }
 
 // func Test_GetEvents(t *testing.T) {
@@ -130,6 +144,7 @@ func Test_SteamOnboarding_Success(t *testing.T) {
 	t.Logf("response: %v", response)
 
 	expectStatus(t, http.StatusCreated, response)
+	expectUUIDHeader(t, "X-Resource-Owner-ID", response)
 }
 
 func Test_GoogleOnboarding_Success(t *testing.T) {
@@ -156,6 +171,7 @@ func Test_GoogleOnboarding_Success(t *testing.T) {
 	t.Logf("response: %v", response)
 
 	expectStatus(t, http.StatusCreated, response)
+	expectUUIDHeader(t, "X-Resource-Owner-ID", response)
 }
 
 func LoadFile(path string) ([]byte, error) {


### PR DESCRIPTION
* Added unit test for the generated RXN (ResourceOwnership) token on OpenID flows