### PR TITLE
RXN-2 Intended Audience: return X-Resource-Owner-Audience-Type

### DIFF
--- a/cmd/rest-api/controllers/constants.go
+++ b/cmd/rest-api/controllers/constants.go
@@ -1,0 +1,6 @@
+package controllers
+
+const (
+	ResourceOwnerIDHeaderKey      string = "X-Resource-Owner-ID"
+	ResourceOwnerAudTypeHeaderKey string = "X-Resource-Owner-Audience-Type"
+)

--- a/cmd/rest-api/controllers/google_controller.go
+++ b/cmd/rest-api/controllers/google_controller.go
@@ -75,7 +75,8 @@ func (c *GoogleController) OnboardGoogleUser(apiContext context.Context) http.Ha
 
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("X-Resource-Owner-ID", ridToken.GetID().String())
+		w.Header().Set(ResourceOwnerIDHeaderKey, ridToken.GetID().String())
+		w.Header().Set(ResourceOwnerAudTypeHeaderKey, string(ridToken.IntendedAudience))
 		json.NewEncoder(w).Encode(googleUser)
 	}
 }

--- a/cmd/rest-api/controllers/steam_controller.go
+++ b/cmd/rest-api/controllers/steam_controller.go
@@ -75,7 +75,8 @@ func (c *SteamController) OnboardSteamUser(apiContext context.Context) http.Hand
 
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("X-Resource-Owner-ID", ridToken.GetID().String())
+		w.Header().Set(ResourceOwnerIDHeaderKey, ridToken.GetID().String())
+		w.Header().Set(ResourceOwnerAudTypeHeaderKey, string(ridToken.IntendedAudience))
 		json.NewEncoder(w).Encode(steamUser)
 	}
 }

--- a/cmd/rest-api/middlewares/resource_context_middleware.go
+++ b/cmd/rest-api/middlewares/resource_context_middleware.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golobby/container/v3"
 	"github.com/google/uuid"
+	"github.com/psavelis/team-pro/replay-api/cmd/rest-api/controllers"
 	common "github.com/psavelis/team-pro/replay-api/pkg/domain"
 	iam_in "github.com/psavelis/team-pro/replay-api/pkg/domain/iam/ports/in"
 )
@@ -35,7 +36,7 @@ func (m *ResourceContextMiddleware) Handler(next http.Handler) http.Handler {
 		ctx = context.WithValue(ctx, common.GroupIDKey, uuid.New())
 		ctx = context.WithValue(ctx, common.UserIDKey, uuid.New())
 
-		rid := r.Header.Get("X-Resource-Owner-ID")
+		rid := r.Header.Get(controllers.ResourceOwnerIDHeaderKey)
 		if rid == "" {
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
@@ -43,7 +44,7 @@ func (m *ResourceContextMiddleware) Handler(next http.Handler) http.Handler {
 
 		reso, aud, err := m.VerifyRID.Exec(ctx, uuid.MustParse(rid))
 		if err != nil {
-			slog.ErrorContext(ctx, "unable to verify rid", "X-Resource-Owner-ID", rid)
+			slog.ErrorContext(ctx, "unable to verify rid", controllers.ResourceOwnerIDHeaderKey, rid)
 			http.Error(w, "unknown", http.StatusUnauthorized)
 		}
 

--- a/pkg/domain/context.go
+++ b/pkg/domain/context.go
@@ -13,9 +13,5 @@ const (
 	GameIDParamKey  ContextKey = "game_id"
 	MatchIDParamKey ContextKey = "match_id"
 
-	// Request (ie: msg header, meta)
-	RequestIDKey            ContextKey = "x-request-id"
-	ResourceOwnerIDParamKey ContextKey = "X-Resource-Owner-ID"
-
 	AudienceKey ContextKey = "aud"
 )

--- a/pkg/domain/search.go
+++ b/pkg/domain/search.go
@@ -106,7 +106,7 @@ type Search struct {
 }
 
 func GetIntendedAudience(ctx context.Context) *IntendedAudienceKey {
-	audience, ok := ctx.Value("aud").(IntendedAudienceKey)
+	audience, ok := ctx.Value(AudienceKey).(IntendedAudienceKey)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
# Context
Returns the **Intended Audience**  (`X-Resource-Owner-Audience-Type`) header on RID Token response after OpenID onboarding.

[RXN-2](https://leetgaming.atlassian.net/browse/RXN-2) 

[RXN-2]: https://leetgaming.atlassian.net/browse/RXN-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ