### PR TITLE
RXN-6 add GET /memberships for listing user x group relation

### DIFF
--- a/cmd/rest-api/controllers/query/search_controller.go
+++ b/cmd/rest-api/controllers/query/search_controller.go
@@ -41,6 +41,7 @@ func NewSearchMux(c *container.Container) *SearchableResourceMultiplexer {
 
 	smux.Handlers[common.ResourceTypeGameEvent] = NewEventSearchController(c)
 	smux.Handlers[common.ResourceTypeProfile] = NewProfileSearchController(c)
+	smux.Handlers[common.ResourceTypeMembership] = NeMembershipSearchController(c)
 	// smux.Handlers[common.ResourceTypeTeam] = NewTeamSearchController(c)
 	smux.ResourceTypes = make([]common.ResourceType, len(smux.Handlers))
 
@@ -186,6 +187,20 @@ func NewProfileSearchController(c *container.Container) *SearchController[iam_en
 	}
 
 	return &SearchController[iam_entities.Profile]{
+		Searchable: s,
+	}
+}
+
+func NeMembershipSearchController(c *container.Container) *SearchController[iam_entities.Membership] {
+	var s iam_in.MembershipReader
+	err := c.Resolve(&s)
+
+	if err != nil {
+		slog.Error("Cannot resolve iam_entities.MembershipReader for NeMembershipSearchController", "err", err)
+		panic(err)
+	}
+
+	return &SearchController[iam_entities.Membership]{
 		Searchable: s,
 	}
 }

--- a/pkg/domain/iam/entities/membership.go
+++ b/pkg/domain/iam/entities/membership.go
@@ -17,10 +17,22 @@ const (
 
 type Membership struct {
 	ID            uuid.UUID            `json:"id" bson:"_id"`
-	GroupID       uuid.UUID            `json:"group_id" bson:"group_id"`
-	UserID        uuid.UUID            `json:"user_id" bson:"user_id"`
 	Type          MembershipType       `json:"type" bson:"type"`
 	ResourceOwner common.ResourceOwner `json:"resource_owner" bson:"resource_owner"`
 	CreatedAt     time.Time            `json:"created_at" bson:"created_at"`
 	UpdatedAt     time.Time            `json:"updated_at" bson:"updated_at"`
+}
+
+func (m Membership) GetID() uuid.UUID {
+	return m.ID
+}
+
+func NewMembership(membershipType MembershipType, resourceOwner common.ResourceOwner) *Membership {
+	return &Membership{
+		ID:            uuid.New(),
+		Type:          membershipType,
+		ResourceOwner: resourceOwner,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
 }

--- a/pkg/domain/iam/ports/in/query.go
+++ b/pkg/domain/iam/ports/in/query.go
@@ -8,3 +8,7 @@ import (
 type ProfileReader interface {
 	common.Searchable[iam_entities.Profile]
 }
+
+type MembershipReader interface {
+	common.Searchable[iam_entities.Membership]
+}

--- a/pkg/domain/iam/ports/out/cmd.go
+++ b/pkg/domain/iam/ports/out/cmd.go
@@ -4,11 +4,10 @@ import (
 	"context"
 
 	iam_entities "github.com/psavelis/team-pro/replay-api/pkg/domain/iam/entities"
-	iam_entity "github.com/psavelis/team-pro/replay-api/pkg/domain/iam/entities"
 )
 
 type RIDTokenWriter interface {
-	Create(ctx context.Context, rid *iam_entity.RIDToken) (*iam_entity.RIDToken, error)
+	Create(ctx context.Context, rid *iam_entities.RIDToken) (*iam_entities.RIDToken, error)
 }
 
 type UserWriter interface {
@@ -24,4 +23,9 @@ type GroupWriter interface {
 type ProfileWriter interface {
 	CreateMany(createCtx context.Context, events []*iam_entities.Profile) error
 	Create(createCtx context.Context, events *iam_entities.Profile) (*iam_entities.Profile, error)
+}
+
+type MembershipWriter interface {
+	CreateMany(createCtx context.Context, events []*iam_entities.Membership) error
+	Create(createCtx context.Context, events *iam_entities.Membership) (*iam_entities.Membership, error)
 }

--- a/pkg/domain/iam/ports/out/query.go
+++ b/pkg/domain/iam/ports/out/query.go
@@ -15,6 +15,10 @@ type ProfileReader interface {
 	common.Searchable[iam_entity.Profile]
 }
 
+type MembershipReader interface {
+	common.Searchable[iam_entity.Membership]
+}
+
 type UserReader interface {
 	Search(ctx context.Context, s common.Search) ([]iam_entity.User, error)
 }

--- a/pkg/domain/iam/services/membership_query_service.go
+++ b/pkg/domain/iam/services/membership_query_service.go
@@ -1,0 +1,38 @@
+package iam_query_services
+
+import (
+	common "github.com/psavelis/team-pro/replay-api/pkg/domain"
+	iam_entities "github.com/psavelis/team-pro/replay-api/pkg/domain/iam/entities"
+)
+
+type MembershipQueryService struct {
+	common.BaseQueryService[iam_entities.Membership]
+}
+
+func NewwMembershipQueryService(MembershipReader common.Searchable[iam_entities.Membership]) *MembershipQueryService {
+	queryableFields := map[string]bool{
+		"ID":            true,
+		"Type":          common.ALLOW,
+		"ResourceOwner": common.ALLOW,
+		"CreatedAt":     true,
+		"UpdatedAt":     true,
+	}
+
+	readableFields := map[string]bool{
+		"ID":            true,
+		"Type":          true,
+		"ResourceOwner": true,
+		"CreatedAt":     true,
+		"UpdatedAt":     true,
+	}
+
+	return &MembershipQueryService{
+		BaseQueryService: common.BaseQueryService[iam_entities.Membership]{
+			Reader:          MembershipReader,
+			QueryableFields: queryableFields,
+			ReadableFields:  readableFields,
+			MaxPageSize:     100,
+			Audience:        common.UserAudienceIDKey,
+		},
+	}
+}

--- a/pkg/domain/iam/use_cases/onboard_openid_user.go
+++ b/pkg/domain/iam/use_cases/onboard_openid_user.go
@@ -18,22 +18,24 @@ const (
 )
 
 type OnboardOpenIDUserUseCase struct {
-	UserReader     iam_out.UserReader
-	UserWriter     iam_out.UserWriter
-	ProfileReader  iam_out.ProfileReader
-	ProfileWriter  iam_out.ProfileWriter
-	GroupWriter    iam_out.GroupWriter
-	CreateRIDToken iam_in.CreateRIDTokenCommand
+	UserReader       iam_out.UserReader
+	UserWriter       iam_out.UserWriter
+	ProfileReader    iam_out.ProfileReader
+	ProfileWriter    iam_out.ProfileWriter
+	GroupWriter      iam_out.GroupWriter
+	MembershipWriter iam_out.MembershipWriter
+	CreateRIDToken   iam_in.CreateRIDTokenCommand
 }
 
-func NewOnboardOpenIDUserUseCase(userReader iam_out.UserReader, userWriter iam_out.UserWriter, profileReader iam_out.ProfileReader, profileWriter iam_out.ProfileWriter, groupWriter iam_out.GroupWriter, createRIDToken iam_in.CreateRIDTokenCommand) *OnboardOpenIDUserUseCase {
+func NewOnboardOpenIDUserUseCase(userReader iam_out.UserReader, userWriter iam_out.UserWriter, profileReader iam_out.ProfileReader, profileWriter iam_out.ProfileWriter, groupWriter iam_out.GroupWriter, membershipWriter iam_out.MembershipWriter, createRIDToken iam_in.CreateRIDTokenCommand) *OnboardOpenIDUserUseCase {
 	return &OnboardOpenIDUserUseCase{
-		UserReader:     userReader,
-		UserWriter:     userWriter,
-		ProfileReader:  profileReader,
-		ProfileWriter:  profileWriter,
-		GroupWriter:    groupWriter,
-		CreateRIDToken: createRIDToken,
+		UserReader:       userReader,
+		UserWriter:       userWriter,
+		ProfileReader:    profileReader,
+		ProfileWriter:    profileWriter,
+		GroupWriter:      groupWriter,
+		MembershipWriter: membershipWriter,
+		CreateRIDToken:   createRIDToken,
 	}
 }
 
@@ -98,6 +100,16 @@ func (uc *OnboardOpenIDUserUseCase) Exec(ctx context.Context, cmd iam_in.Onboard
 
 	if err != nil {
 		slog.ErrorContext(ctx, "error creating group", "err",
+			err)
+		return nil, nil, err
+	}
+
+	membership := iam_entities.NewMembership(iam_entities.MembershipTypeOwner, rxn)
+
+	_, err = uc.MembershipWriter.Create(ctx, membership)
+
+	if err != nil {
+		slog.ErrorContext(ctx, "error creating membership", "err",
 			err)
 		return nil, nil, err
 	}

--- a/pkg/domain/resource.go
+++ b/pkg/domain/resource.go
@@ -46,6 +46,7 @@ const (
 	ResourceTypeLeague     ResourceType = "Leagues"     // specification of user group
 	ResourceTypeTournament ResourceType = "Tournaments" // specification of user group
 	ResourceTypeProfile    ResourceType = "Profiles"    // specification of user group
+	ResourceTypeMembership ResourceType = "Memberships" // specification of user group
 	ResourceTypePage       ResourceType = "Pages"       //
 	ResourceTypeFriends    ResourceType = "Friends"
 	ResourceTypeList       ResourceType = "List" // recurse root resources (?)

--- a/pkg/infra/db/mongodb/membership_mongodb.go
+++ b/pkg/infra/db/mongodb/membership_mongodb.go
@@ -1,0 +1,44 @@
+package db
+
+import (
+	"reflect"
+
+	"go.mongodb.org/mongo-driver/mongo"
+
+	iam_entities "github.com/psavelis/team-pro/replay-api/pkg/domain/iam/entities"
+)
+
+type MembershipRepository struct {
+	MongoDBRepository[iam_entities.Membership]
+}
+
+func NewMembershipRepository(client *mongo.Client, dbName string, entityType *iam_entities.Membership, collectionName string) *MembershipRepository {
+	repo := MongoDBRepository[iam_entities.Membership]{
+		mongoClient:       client,
+		dbName:            dbName,
+		mappingCache:      make(map[string]CacheItem),
+		entityModel:       reflect.TypeOf(entityType),
+		bsonFieldMappings: make(map[string]string),
+		collectionName:    collectionName,
+		entityName:        reflect.TypeOf(entityType).Name(),
+		queryableFields:   make(map[string]bool),
+	}
+
+	repo.InitQueryableFields(map[string]bool{
+		"ID":            true,
+		"Type":          true,
+		"ResourceOwner": true,
+		"CreatedAt":     true,
+		"UpdatedAt":     true,
+	}, map[string]string{
+		"ID":            "_id",
+		"Type":          "type",
+		"ResourceOwner": "resource_owner",
+		"CreatedAt":     "created_at",
+		"UpdatedAt":     "updated_at",
+	})
+
+	return &MembershipRepository{
+		repo,
+	}
+}

--- a/test/cmd/rest-api-test/http_api_test.go
+++ b/test/cmd/rest-api-test/http_api_test.go
@@ -172,8 +172,10 @@ func Test_SteamOnboarding_Success(t *testing.T) {
 	expectHeader(t, controllers.ResourceOwnerAudTypeHeaderKey, response, common.UserAudienceIDKey)
 
 	// should query the profile
+
+	rid := response.Header().Get(controllers.ResourceOwnerIDHeaderKey)
 	req = httptest.NewRequest("GET", strings.Replace(routing.Search, "{query:.*}", "profiles?Type=steam&Details.ID=12345", -1), nil)
-	req.Header.Add(controllers.ResourceOwnerIDHeaderKey, response.Header().Get(controllers.ResourceOwnerIDHeaderKey))
+	req.Header.Add(controllers.ResourceOwnerIDHeaderKey, rid)
 
 	response = tester.Exec(req)
 
@@ -181,7 +183,14 @@ func Test_SteamOnboarding_Success(t *testing.T) {
 
 	expectStatus(t, http.StatusOK, response)
 
-	// should query the steam user
+	// should query groups by listing memberships
+
+	req = httptest.NewRequest("GET", strings.Replace(routing.Search, "{query:.*}", "memberships", -1), nil)
+	req.Header.Add(controllers.ResourceOwnerIDHeaderKey, rid)
+	response = tester.Exec(req)
+	t.Logf("response: %v", response)
+
+	expectStatus(t, http.StatusOK, response)
 
 }
 


### PR DESCRIPTION
# Context
Introduce `Membership` entity & endpoint in order to list user vs. group relation

`GET /memberships`: retrieves all user groups & relation type (ie.: member/admin/owner)

[RXN-6](https://leetgaming.atlassian.net/browse/RXN-6)


[RXN-6]: https://leetgaming.atlassian.net/browse/RXN-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ