### PR TITLE
Fix IoC container for tournament usecases

### DIFF
--- a/pkg/infra/ioc/container.go
+++ b/pkg/infra/ioc/container.go
@@ -3160,7 +3160,7 @@ func InjectMongoDB(c container.Container) error {
 		// 	return nil, err
 		// }
 
-		return tournament_usecases.NewRegisterForTournamentUseCase(billableOperationHandler, tournamentRepo), nil
+		return tournament_usecases.NewRegisterForTournamentUseCase(billableOperationHandler, tournamentRepo, nil), nil
 	})
 	if err != nil {
 		slog.Error("Failed to load RegisterForTournamentUseCase.", "err", err)


### PR DESCRIPTION
Update IoC container to pass nil for the disabled playerProfileReader parameter in RegisterForTournamentUseCase constructor.